### PR TITLE
Update API URLs and Stripe settings in configuration files

### DIFF
--- a/_geodata/seed-location2.sh
+++ b/_geodata/seed-location2.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 #   LOGIN_EMAIL=aethon@localhost.com
 #   LOGIN_PASSWORD='Aethon@Admin2026!'
 
-AUTH_URL="${AUTH_URL:-http://localhost:5201/api/v1/auth/login}"
-BULK_URL="${BULK_URL:-http://localhost:5201/api/v1/admin/locations/bulk}"
+AUTH_URL="${AUTH_URL:-https://dev-api.app.aethonsoftware.com/api/v1/auth/login}"
+BULK_URL="${BULK_URL:-https://dev-api.app.aethonsoftware.com/api/v1/admin/locations/bulk}"
 LOGIN_EMAIL="${LOGIN_EMAIL:-aethon@localhost.com}"
 LOGIN_PASSWORD="${LOGIN_PASSWORD:-Aethon@Admin2026!}"
 

--- a/seed-stripe-settings.zsh
+++ b/seed-stripe-settings.zsh
@@ -23,8 +23,8 @@ set -euo pipefail
 #   Stripe.Price.Sticky.Verified.24h=price_ghi
 #   Stripe.Price.Sticky.Verified.7d=price_jkl
 
-AUTH_URL="${AUTH_URL:-http://localhost:5201/api/v1/auth/login}"
-SETTINGS_BASE_URL="${SETTINGS_BASE_URL:-http://localhost:5201/api/v1/admin/settings}"
+AUTH_URL="${AUTH_URL:-https://dev-api.app.aethonsoftware.com/api/v1/auth/login}"
+SETTINGS_BASE_URL="${SETTINGS_BASE_URL:-https://dev-api.app.aethonsoftware.com/api/v1/admin/settings}"
 LOGIN_EMAIL="${LOGIN_EMAIL:-aethon@localhost.com}"
 LOGIN_PASSWORD="${LOGIN_PASSWORD:-Aethon@Admin2026!}"
 

--- a/src/Aethon.Web/Components/Pages/Admin/StripeEvents/Index.razor
+++ b/src/Aethon.Web/Components/Pages/Admin/StripeEvents/Index.razor
@@ -308,7 +308,9 @@ else
         try
         {
             var client = await Api.CreateAsync();
-            var url = $"/api/v1/admin/stripe-events?page={_page}&status={Uri.EscapeDataString(_statusFilter)}";
+            var url = string.IsNullOrEmpty(_statusFilter)
+                ? $"/api/v1/admin/stripe-events?page={_page}"
+                : $"/api/v1/admin/stripe-events?page={_page}&status={Uri.EscapeDataString(_statusFilter)}";
             var result = await client.GetFromJsonAsync<PagedResult<EventRow>>(url, AethonApiClient.JsonOptions);
             if (result is not null) { _events = result.Items; _total = result.Total; }
         }

--- a/stripe-settings.env
+++ b/stripe-settings.env
@@ -2,7 +2,7 @@
 Stripe.SecretKey=sk_test_51SJ3Xb4BF2uOrrJbVIm8OTvuK3vvM95s3ykjHsXvvBQI6EqLml5eExfpsTtSAlDyht80h4cnrGnQBi8rHd1bZxzZ00Rkt5z0jS
 
 # Webhook
-Stripe.WebhookSecret=whsec_123
+Stripe.WebhookSecret=whsec_M75eMg41oQarsEpoy4dYSeX8lAtmNweP
 
 # Verification
 Stripe.Price.VerificationStandard=price_1TDOxX4BF2uOrrJbveZSNuiX
@@ -44,14 +44,14 @@ Stripe.Price.Addon.AiMatching=price_1TET0G4BF2uOrrJbE6ioEPSe
 # Update these whenever Stripe pricing changes.
 
 Display.Price.Job.Standard.1x=19
-Display.Price.Job.Standard.5x=
-Display.Price.Job.Standard.10x=
-Display.Price.Job.Standard.20x=
+Display.Price.Job.Standard.5x=85
+Display.Price.Job.Standard.10x=160
+Display.Price.Job.Standard.20x=299
 
-Display.Price.Job.Premium.1x=69
-Display.Price.Job.Premium.5x=
-Display.Price.Job.Premium.10x=
-Display.Price.Job.Premium.20x=
+Display.Price.Job.Premium.1x=29
+Display.Price.Job.Premium.5x=129
+Display.Price.Job.Premium.10x=239
+Display.Price.Job.Premium.20x=449
 
 Display.Price.Verification.Standard=49
 Display.Price.Verification.Enhanced=149
@@ -62,9 +62,9 @@ Display.Price.Addon.Highlight=9
 Display.Price.Addon.Video=9
 Display.Price.Addon.AiMatching=9
 
-Display.Price.Sticky.Verified.24h=
-Display.Price.Sticky.Verified.7d=
-Display.Price.Sticky.Verified.30d=
-Display.Price.Sticky.Unverified.24h=
-Display.Price.Sticky.Unverified.7d=
-Display.Price.Sticky.Unverified.30d=
+Display.Price.Sticky.Verified.24h=9
+Display.Price.Sticky.Verified.7d=39
+Display.Price.Sticky.Verified.30d=99
+Display.Price.Sticky.Unverified.24h=15
+Display.Price.Sticky.Unverified.7d=59
+Display.Price.Sticky.Unverified.30d=149


### PR DESCRIPTION
This pull request updates environment variables, API endpoints, and UI logic related to Stripe settings and admin endpoints. The main focus is on switching from local to development API URLs, updating Stripe secrets and pricing, and improving how the admin UI handles event filtering.

**Environment and API endpoint updates:**

- Updated default `AUTH_URL` and related admin endpoints in both `_geodata/seed-location2.sh` and `seed-stripe-settings.zsh` scripts to use the development API (`https://dev-api.app.aethonsoftware.com`) instead of localhost. [[1]](diffhunk://#diff-be8d1ea8c99b02eb0e939c3a65adb58b4c84de493e1a1bd8aa1dc5d455aab9b7L20-R21) [[2]](diffhunk://#diff-a816626b3cddae87e01a94d82c3c93e975a59efe1d5b8980df62b8cf3bd1772dL26-R27)

**Stripe configuration and pricing changes:**

- Changed the `Stripe.WebhookSecret` value in `stripe-settings.env` to a new secret key.
- Updated display pricing for standard and premium jobs, as well as sticky and addon pricing, in `stripe-settings.env` to reflect new values. [[1]](diffhunk://#diff-54769b68f9d8ed6feb04b76d461ee246918c4ef46306d6823a79733e97ad0a1cL47-R54) [[2]](diffhunk://#diff-54769b68f9d8ed6feb04b76d461ee246918c4ef46306d6823a79733e97ad0a1cL65-R70)

**Admin UI improvements:**

- Modified the logic in `src/Aethon.Web/Components/Pages/Admin/StripeEvents/Index.razor` so that the status filter is only included in the API request if a filter is set, preventing unnecessary query parameters.