### PR TITLE
Update recruiter partners icon in navigation menu

### DIFF
--- a/src/Aethon.Web/Components/Layout/NavMenu.razor
+++ b/src/Aethon.Web/Components/Layout/NavMenu.razor
@@ -31,7 +31,7 @@
             </NavLink>
 
             <NavLink class="nav-link aethon-nav-link" href="/company/recruiters" Match="NavLinkMatch.Prefix">
-                <span class="aethon-nav-icon"><i class="bi bi-handshake text-warning"></i></span>
+                <span class="aethon-nav-icon"><i class="bi bi-people-fill text-warning"></i></span>
                 <span>Recruiter partners</span>
             </NavLink>
 


### PR DESCRIPTION
This pull request makes a small UI update to the navigation menu, specifically changing the icon for the "Recruiter partners" navigation link.

- Replaced the handshake icon (`bi-handshake`) with a people icon (`bi-people-fill`) for the "Recruiter partners" navigation link in `NavMenu.razor` to better represent the section.